### PR TITLE
fix: Update ed25519-dalek to 3.0 and rand to 0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,12 +610,6 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
@@ -745,19 +739,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.3"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest 0.10.7",
+ "digest 0.11.2",
  "fiat-crypto",
+ "rand_core 0.10.1",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -827,11 +823,11 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
 dependencies = [
- "const-oid 0.9.6",
+ "const-oid",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -863,7 +859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
 dependencies = [
  "block-buffer 0.12.0",
- "const-oid 0.10.2",
+ "const-oid",
  "crypto-common 0.2.1",
 ]
 
@@ -903,9 +899,9 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ed25519"
-version = "2.2.3"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
 dependencies = [
  "pkcs8",
  "signature",
@@ -913,15 +909,16 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
  "serde",
- "sha2 0.10.9",
+ "sha2 0.11.0",
+ "signature",
  "subtle",
  "zeroize",
 ]
@@ -1015,7 +1012,7 @@ dependencies = [
  "hex",
  "jsonschema",
  "polars",
- "rand 0.8.5",
+ "rand 0.10.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -1072,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.9"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
@@ -2273,9 +2270,9 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.7.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
 dependencies = [
  "base64ct",
 ]
@@ -2332,9 +2329,9 @@ checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkcs8"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
 dependencies = [
  "der",
  "spki",
@@ -3098,22 +3095,11 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
+ "rand_chacha",
  "rand_core 0.9.3",
 ]
 
@@ -3130,31 +3116,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -3774,11 +3741,11 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -3866,9 +3833,9 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
 dependencies = [
  "base64ct",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ typed-builder = "0.23.2"
 url = "2.5.4"
 sha2 = "0.11.0"
 hex = "0.4.3"
-ed25519-dalek = { version = "2.2.0", features = ["rand_core", "pkcs8", "pem"] }
-rand = { version = "0.8", optional = true }
+ed25519-dalek = { version = "3.0.0", features = ["rand_core", "pkcs8", "pem"] }
+rand = { version = "0.10", optional = true }
 polars = { version = "0.54", default-features = false, features = ["lazy", "dtype-datetime"], optional = true }
 
 [dev-dependencies]

--- a/src/container.rs
+++ b/src/container.rs
@@ -115,7 +115,7 @@ impl ContainerBuilder {
     /// The private key will be used to sign events and the public key will be used to verify them.
     #[must_use]
     pub fn with_signing_key(mut self) -> Self {
-        let mut rng: ThreadRng = rand::thread_rng();
+        let mut rng: ThreadRng = rand::rng();
         self.signing_key = Some(SigningKey::generate(&mut rng));
         self
     }


### PR DESCRIPTION
## Was & warum

Führt die beiden offenen Dependabot-PRs zusammen und macht die QA-Pipeline wieder grün:

- #137 – `ed25519-dalek` 2.2.0 → **3.0.0**
- #118 – `rand` 0.8.5 → **0.10.1**

Beide Bumps scheitern **einzeln** an QA und lassen sich nur **gemeinsam** lösen:

- `rand` allein → `SigningKey::generate` erwartet weiterhin den alten `rand_core`-Trait → `ThreadRng: CryptoRng` nicht erfüllt (E0277).
- `ed25519-dalek` allein → `rand::thread_rng()` existiert in rand 0.10 nicht mehr (E0425).

Erst gemeinsam landen beide Crates auf derselben `rand_core`-Generation, wodurch `SigningKey::generate` wieder das `ThreadRng` von `rand` akzeptiert.

## Code-Änderung

Betroffen ist eine einzige Stelle – `Container::with_signing_key` in `src/container.rs`:

```diff
-        let mut rng: ThreadRng = rand::thread_rng();
+        let mut rng: ThreadRng = rand::rng();
```

(`rand::thread_rng()` wurde in rand 0.9 zu `rand::rng()` umbenannt und in 0.10 entfernt.) Dazu die Versionsanhebungen in `Cargo.toml`/`Cargo.lock`. Sonst keine Anpassungen nötig.

## Lokale Verifikation

- `cargo check --features testcontainer` ✅
- `cargo clippy` (mit & ohne Feature) ✅ keine Warnungen
- `cargo fmt --check` ✅
- `cargo doc --all-features --no-deps --document-private-items` ✅
- `cargo test --features testcontainer --no-run` ✅ (Test-Ausführung selbst braucht Docker)

## Auswirkung auf Nutzer

- **`rand`: keine.** Optionale Dependency hinter dem `testcontainer`-Feature, ausschließlich intern genutzt, nicht Teil der öffentlichen API.
- **`ed25519-dalek`: semver-relevant.** Dessen Typen liegen in der öffentlichen API (`Event::verify_signature(&VerifyingKey)`, `Container::get_verifying_key() -> Option<&VerifyingKey>`, Fehler-Varianten über `SignatureError`/`pkcs8::Error`). Das SDK re-exportiert `ed25519-dalek` nicht, d. h. Konsumenten, die diese Methoden nutzen, müssen ihre eigene `ed25519-dalek`-Abhängigkeit ebenfalls auf 3.0 heben. Methodensignaturen und Verhalten bleiben identisch.

> **Hinweis zur Versionierung:** Dieser Commit ist als `fix:` (→ Patch-Bump via `get-next-version`) formuliert. Wegen des durchgereichten Major-Bumps von `ed25519-dalek` könnte stattdessen ein Breaking-Change-Marker angemessen sein. Bitte vor dem Merge entscheiden.

Ersetzt #137 und #118.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApjzmLRvrTyvecCLRMuGWW)_